### PR TITLE
Test return type of res.json()

### DIFF
--- a/issues.py
+++ b/issues.py
@@ -203,7 +203,8 @@ class Issues(object):
             url = f'{github}/repos/{source}/issues/{int(issue_id)}'
             print(url)
             res = self.grequest.get(url)
-            new_issue = json.loads(res.json())
+            content = res.json()
+            new_issue = content if type(content) is dict else json.loads(content)
             issues.append(new_issue)
 
         return issues


### PR DESCRIPTION
the requests json() method seems to return a dict, so it doesn't need to be converted to one. But maybe some versions don't return a dict, so we'll just test it.