### PR TITLE
Adjust Issue Order

### DIFF
--- a/backlog_issues.py
+++ b/backlog_issues.py
@@ -42,7 +42,6 @@ class Issues(object):
             new_issue['body'] = self.format_issue(template_data)
             issues_to_migrate.append(new_issue)
 
-        issues_to_migrate.reverse()
         organized_issues = self.organize_issues(issues_to_migrate)
 
         if self.config.has_option('target', 'repository'):
@@ -146,7 +145,6 @@ class Issues(object):
             choice = ord(sys.stdin.read(1))
 
         termios.tcsetattr(fd, termios.TCSADRAIN, old)
-        issues.reverse()
         return issues
 
     def format_from_template(self, template_filename, template_data):

--- a/backlog_project.py
+++ b/backlog_project.py
@@ -85,7 +85,7 @@ class ProjectBoard(object):
         url = f'https://api.github.com/projects/columns/{backlog}/cards'
         print(f'Adding open issues to {url}')
 
-        for issue in issues:
+        for issue in reversed(issues):
             data = {
                 "content_id": issue["id"],
                 "content_type": "Issue"


### PR DESCRIPTION
There is some confusion about the order of issues. This change ensures the following:

_Some of these things were already true, but I can't remember which ones :)_

1. The default issue order is based on the issue numbers from the source repo
2. When adjusting the order of issues, the most important are on the top
3. When adding issues to the target repo, higher priority issues are added first in order to have lower issue numbers
4. When adding issues (aka cards) to the project, lower priority issues are added first so that they are at the bottom of the column
